### PR TITLE
Add concurrency rule to docusaurus.yaml

### DIFF
--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -44,7 +44,7 @@ jobs:
           retention-days: 7
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == workflow_dispatch || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -10,6 +10,11 @@ on:
       - ready_for_review
       - reopened
       - synchronize
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
I also added a way to manually re-trigger a documentation build and deploy using a workflow dispatch.